### PR TITLE
Make --header argument optional for decrypt

### DIFF
--- a/crypt4gh_recryptor/__main__.py
+++ b/crypt4gh_recryptor/__main__.py
@@ -58,8 +58,9 @@ def main():
     ap_d.add_argument(
         "--header",
         dest="header_file",
-        required=True,
-        help="The alternate header file to be used to decrypt"
+        default=None,
+        help="An optional alternate header file to be used to decrypt. If defined, the header of the encrypted input "
+             "file will be ignored"
     )
     
     ap_g = sp.add_parser(
@@ -134,7 +135,8 @@ def main():
     
     retval = 1
     if args.operation == "decrypt":
-        retval = do_decrypt_payload(args.input_file, args.header_file, args.decryption_key, args.output_file)
+        retval = do_decrypt_payload(args.input_file, args.header_file, args.decryption_key, args.output_file,
+                                    skip_header=args.header_file is not None)
     elif args.operation == "recrypt":
         retval = do_recrypt_header(args.input_file, args.decryption_key, args.encryption_keys, args.output_file)
     elif args.operation == "get-header":

--- a/crypt4gh_recryptor/operations.py
+++ b/crypt4gh_recryptor/operations.py
@@ -138,7 +138,8 @@ def do_decrypt_payload(payload_file: "str", header_file: "Optional[str]", decryp
             if skip_header:
                 logger.info(f"Skipping header of {payload_file}")
                 # This one is going to be discarded
-
+                for _ in crypt4gh.header.parse(pstream):
+                    pass
             istream = MultiStreamReader(hstream, pstream)
         else:
             istream = open(payload_file, mode="rb")

--- a/crypt4gh_recryptor/operations.py
+++ b/crypt4gh_recryptor/operations.py
@@ -115,7 +115,7 @@ class MultiStreamReader(io.RawIOBase):
 
 logger = logging.getLogger(__name__)
 
-def do_decrypt_payload(payload_file: "str", header_file: "str", decryption_key_file: "str", output_file: "str", sender_key_file: "Optional[str]" = None, skip_header: "bool" = False, decryption_passphrase: "Optional[str]" = None) -> "int":
+def do_decrypt_payload(payload_file: "str", header_file: "Optional[str]", decryption_key_file: "str", output_file: "str", sender_key_file: "Optional[str]" = None, skip_header: "bool" = False, decryption_passphrase: "Optional[str]" = None) -> "int":
     try:
         decryption_key = crypt4gh.keys.get_private_key(decryption_key_file, lambda: decryption_passphrase)
     except:
@@ -132,12 +132,16 @@ def do_decrypt_payload(payload_file: "str", header_file: "str", decryption_key_f
         sender_pub_key = None
     
     try:
-        hstream = open(header_file, mode="rb")
-        pstream = open(payload_file, mode="rb")
-        if skip_header:
-            # This one is going to be discarded
-            _ = crypt4gh.header.parse(pstream)
-        istream = MultiStreamReader(hstream, pstream)
+        if header_file:
+            hstream = open(header_file, mode="rb")
+            pstream = open(payload_file, mode="rb")
+            if skip_header:
+                logger.info(f"Skipping header of {payload_file}")
+                # This one is going to be discarded
+
+            istream = MultiStreamReader(hstream, pstream)
+        else:
+            istream = open(payload_file, mode="rb")
     except:
         logger.exception(f"Unable to open either header from {header_file} or payload from {payload_file} in order to decrypt the latter")
         return 3

--- a/test_data/README
+++ b/test_data/README
@@ -1,5 +1,5 @@
 ### Test Data
-Test datasets and keys used for the WP2 demomstrator
+Test datasets and keys used for the WP2 demonstrator
 
 - Pair of curve25519-based keys for the two actors involved in the flow
     - FEGA node: initial data storage


### PR DESCRIPTION
Even though we may not use it directly, it is convenient for consistency checks during testing to be able to decode a input file with the included header. Consequenctly, the  '--header' arg of decrypt should be made optional.

This PR also includes a bugfix on the skip_header functionality, which did not work as intended (crypt4gh.header.parse() returns a generator and does not in itself read anything).